### PR TITLE
Remove unnecessarily large documentation header

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: documentation
+title: Introduction
 ---
 
 # The Lounge

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, user-scalable=no">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-	<title>{{ site.title }}</title>
+	<title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
 	<meta name="description" content="{{ site.description }}">
 
 	<link rel="stylesheet" href="{{ site.baseurl }}/css/bootstrap.css">

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -3,15 +3,6 @@ layout: default
 ---
 
 <div id="docs">
-	<div class="header">
-		<div class="container">
-			<div class="row">
-				<div class="col-sm-12">
-					<h2>Documentation</h2>
-				</div>
-			</div>
-		</div>
-	</div>
 	<div id="main" class="container">
 		<div class="row">
 			<aside id="sidebar" class="col-sm-3">

--- a/css/style.css
+++ b/css/style.css
@@ -187,10 +187,8 @@ pre code {
 #features .feature {
 	padding-bottom: 20px;
 }
-#content .header {
-	background: #e4eaee;
-	padding: 40px 0;
-	margin-bottom: 40px;
+#docs {
+	padding-top: 40px;
 }
 #main h1:first-child,
 #main p {


### PR DESCRIPTION
![chrome_2016-05-08_12-17-34](https://cloud.githubusercontent.com/assets/613331/15096999/ed7e9fea-1516-11e6-93c0-856a0aef0834.png)

All it does is take space, it serves no purpose.