### PR TITLE
Fetch package version from NPM

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,10 +1,7 @@
 (function() {
-	$.getJSON("https://api.github.com/repos/thelounge/lounge/tags", function(json) {
-		var first = json.shift();
-		if (first.name) {
-			var version = document.getElementById("version");
-			version.textContent = "version " + first.name.substr(1); // Strip `v` in `vX.Y.Z`
-			version.className = "version_shown";
-		}
-	});
+    $.getJSON("https://registry.npmjs.cf/-/package/thelounge/dist-tags", function(json) {
+            var version = document.getElementById("version");
+            version.textContent = "version " + json["latest"];
+            version.className = "version_shown";
+    });
 }());


### PR DESCRIPTION
Implements #22.

Uses a mirror of NPM, as the official website does not support CORS.

Also of note is that since NPM's latest version is 1.5, the website regresses the version number from it's previous display of 2.0.0