### PR TITLE
Display both stable and pre-release versions when pre-release version is more recent than latest stable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -122,26 +122,25 @@ pre code {
 #splash .hgroup {
 	margin: 60px 0;
 }
-#splash .button {
+#splash .card {
 	background: #84ce88;
 	border-radius: 3px;
 	display: inline-block;
-	padding: 15px 50px;
+	padding: 15px;
+	margin: 5px;
+	min-width: 330px;
 }
-#splash .button strong {
+#splash .card strong {
 	display: block;
 	font-size: 17px;
 	font-family: monospace;
 }
-#splash .button:hover {
-	background: #77ca7b;
-}
-#splash #version {
-	opacity: 0;
-	transition: opacity .2s ease-in;
-}
-#splash #version.version_shown {
+#splash #stable_version,
+#splash #prerelease_version {
 	opacity: .7;
+}
+#splash #prerelease_card.hidden {
+	display: none;
 }
 #features {
 	padding: 50px 0 80px;

--- a/css/style.css
+++ b/css/style.css
@@ -131,6 +131,7 @@ pre code {
 #splash .button strong {
 	display: block;
 	font-size: 17px;
+	font-family: monospace;
 }
 #splash .button:hover {
 	background: #77ca7b;

--- a/index.html
+++ b/index.html
@@ -11,11 +11,20 @@ layout: default
 					<h1>The self-hosted web IRC client</h1>
 					<h2>Always connected.</h2>
 				</div>
-				<a href="https://www.npmjs.org/package/thelounge" class="button">
+
+				<p>Install <a href="https://www.npmjs.org/package/thelounge">The Lounge from npm</a>:</p>
+
+				<div class="card">
 					<strong>npm -g install thelounge</strong>
-					<small id="version">version 0.0.0</small>
-				</a>
-				<p>				
+					<small id="stable_version"></small>
+				</div>
+
+				<div id="prerelease_card" class="card hidden">
+					<strong>npm -g install thelounge@next</strong>
+					<small id="prerelease_version"></small>
+				</div>
+
+				<p>
 					Or try the
 					<a href="https://avatar.playat.ch:1000" target="_blank">demo</a>.
 				</p>

--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,24 @@
 (function() {
 	$.getJSON("https://api.github.com/repos/thelounge/lounge/releases", function(json) {
-		var first = json.filter(function (release) {
-			return !release.prerelease;
-		})[0];
+		var latest = json[0];
+		var stable;
+		var prerelease;
 
-		if (first.tag_name) {
-			var version = document.getElementById("version");
-			version.textContent = "version " + first.tag_name.substr(1); // Strip `v` in `vX.Y.Z`
-			version.className = "version_shown";
+		if (latest.prerelease) {
+			prerelease = latest;
+			stable = json.find(function (release) { return !release.prerelease; });
+		} else {
+			stable = latest;
+		}
+
+		var stable_version = document.getElementById("stable_version");
+		// `.substr(1)` strips `v` in `vX.Y.Z`
+		stable_version.textContent = "version " + stable.tag_name + (prerelease ? " (stable)" : "");
+
+		if (prerelease) {
+			var prerelease_version = document.getElementById("prerelease_version");
+			prerelease_version.textContent = "version " + prerelease.tag_name.substr(1) + " (pre-release)";
+			document.getElementById("prerelease_card").className = "card";
 		}
 	});
 }());

--- a/js/main.js
+++ b/js/main.js
@@ -1,9 +1,12 @@
 (function() {
-	$.getJSON("https://api.github.com/repos/thelounge/lounge/tags", function(json) {
-		var first = json.shift();
-		if (first.name) {
+	$.getJSON("https://api.github.com/repos/thelounge/lounge/releases", function(json) {
+		var first = json.filter(function (release) {
+			return !release.prerelease;
+		})[0];
+
+		if (first.tag_name) {
 			var version = document.getElementById("version");
-			version.textContent = "version " + first.name.substr(1); // Strip `v` in `vX.Y.Z`
+			version.textContent = "version " + first.tag_name.substr(1); // Strip `v` in `vX.Y.Z`
 			version.className = "version_shown";
 		}
 	});


### PR DESCRIPTION
After looking at #26, I realized that the npm website is not CORS enabled (sigh...).
Since I was not too fond of using a mirror, I looked at how we could use the GitHub API for this. Turns out there is no way to know if a tag is a pre-release or not using `/tags`, but there is one using `/releases`.
It goes against #22 as the issue is saying to use npm and this makes bigger use of GitHub, but I now tend to trust the GitHub API more than the npm API. If this changes, and npm enables CORS (or we are OK to use a mirror), it will not be too difficult to update the JS here to retrieve the correct versions.

 | No pre-releases since latest stable | Pre-releases since latest stable
--- | --- | ---
Laptop | <img width=600 alt="screen shot 2016-06-13 at 01 50 13 1" src="https://cloud.githubusercontent.com/assets/113730/15998249/beb8d756-310a-11e6-8730-2a7cf9e67c40.png"> | <img width=630 alt="screen shot 2016-06-13 at 01 49 48" src="https://cloud.githubusercontent.com/assets/113730/15998247/beb8890e-310a-11e6-9084-273b3a0de419.png">
Mobile | <img width="450" alt="screen shot 2016-06-13 at 01 52 23" src="https://cloud.githubusercontent.com/assets/113730/15998248/beb8787e-310a-11e6-8989-266d233bc6a1.png"> | <img width="265" alt="screen shot 2016-06-13 at 01 52 41" src="https://cloud.githubusercontent.com/assets/113730/15998246/beb76baa-310a-11e6-95d7-c63c4bac8214.png">



