### PR TITLE
Fix LOUNGE_HOME doc bug

### DIFF
--- a/_docs/getting_started/usage.md
+++ b/_docs/getting_started/usage.md
@@ -99,7 +99,7 @@ $ lounge edit john
 
 _Set the home path. This is the location where The Lounge will look for the `config.js` and the `users/` folder._
 
-_*Also configurable through the environment variable `LOUNGE_HOME`.*_
+*Also configurable through the environment variable `LOUNGE_HOME`.*
 
 Example:
 


### PR DESCRIPTION
Fixes a parsing issue from #29.

Before | After
--- | ---
<img width="532" alt="screen shot 2016-06-16 at 01 13 59" src="https://cloud.githubusercontent.com/assets/113730/16106124/acdfedba-335f-11e6-8cce-6b1f5b8e9308.png"> | <img width="525" alt="screen shot 2016-06-16 at 01 14 15" src="https://cloud.githubusercontent.com/assets/113730/16106125/ace42f88-335f-11e6-8abf-2b5ffe6f36f7.png">
