### PR TITLE
Remove distro-specific install instructions of Node.js

### DIFF
--- a/_docs/getting_started/install.md
+++ b/_docs/getting_started/install.md
@@ -8,105 +8,16 @@ order: 1.1
 
 # Installing The Lounge
 
-The Lounge requires [nodejs](https://nodejs.org/) and [npm](https://www.npmjs.org/). If you already have them installed on your system, go ahead and install The Lounge:
+The Lounge requires [Node.js](https://nodejs.org/) v4 or more recent, and [npm](https://www.npmjs.org/).
 
-```
-$ sudo npm -g install thelounge
-```
+If you need to install these, follow instructions given on the [official documentation](https://nodejs.org/en/download/package-manager/) by choosing your distribution in the list.
 
-And if you don't &mdash; pick your operating system below:
+You can then install The Lounge using:
 
-## Ubuntu / Debian
-
-### Step 1:
-
-Install the requirements using apt-get:
-
-```
-$ sudo apt-get -y install nodejs-legacy npm
+```sh
+$ [sudo] npm -g install thelounge
 ```
 
-### Step 2:
+## Install complete
 
-Install The Lounge:
-
-```
-$ sudo npm install -g thelounge
-```
-
-## CentOS / Fedora / RHEL
-
-### Step 1:
-
-Install the requirements using yum (Newer version of Fedora, please use dnf instead):
-
-```
-$ sudo yum install epel-release
-$ sudo yum install nodejs npm
-```
-
-### Step 2:
-
-Install The Lounge:
-
-```
-$ sudo npm install -g thelounge
-```
-
-## Mac OSX
-
-### Step 1:
-
-Install [Homebrew](http://brew.sh/).
-
-Copy and paste this snippet into your terminal:
-
-```
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-```
-
-### Step 2:
-
-Install [nodejs](https://nodejs.org):
-
-```
-$ brew install nodejs
-```
-
-### Step 3:
-
-Install The Lounge:
-
-```
-$ sudo npm -g install thelounge
-```
-
-## Windows
-
-### Step 1:
-
-Install [Chocolatey](https://chocolatey.org/).
-
-### Step 2:
-
-Open the Command Prompt as __administrator__ and run this command:
-
-```
-choco install nodejs.install
-```
-
-### Step 3:
-
-Now close your Command Prompt and open the `Node.js Command Prompt` that was just installed on your computer.
-
-### Step 4:
-
-Install The Lounge:
-
-```
-npm install -g thelounge
-```
-
-# Install complete
-
-When you're done installing The Lounge, go ahead to [the next section](/docs/getting_started/usage.html)
+When you're done installing The Lounge, go to [the next section](/docs/getting_started/usage.html)


### PR DESCRIPTION
Fixes #48, fixes #25, supersedes #44.

The main issue with our documentation is that it was advising to install a version of Node that is not compatible with The Lounge!

Turns out, when you remove all the distro-specific instructions for Node on the current version of https://thelounge.github.io/docs/getting_started/install.html, you are left with `npm install -g thelounge` only 😂.

These instructions will clearly need improvements to make good use of what's done in https://github.com/thelounge/docker-lounge, https://github.com/thelounge/deb-lounge and https://github.com/thelounge/arch-lounge, but until then, it fixes the current issue.