### PR TITLE
Remove false information about setting up password along with creating a user

### DIFF
--- a/_docs/getting_started/usage.md
+++ b/_docs/getting_started/usage.md
@@ -53,7 +53,7 @@ Example:
 $ lounge list
 ```
 
-## `add <name> [<password>]`
+## `add <name>`
 
 _Add a new user._
 


### PR DESCRIPTION
This is unlikely going to change (see https://github.com/thelounge/lounge/issues/353) and not anytime soon anyway.

I've only just realized that user management is duplicated at https://thelounge.github.io/docs/getting_started/usage.html and https://thelounge.github.io/docs/server/users.html! The other page does not mention password.
Oooh I am so getting closer and closer to drastically improve our docs...