### PR TITLE
Always render scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,8 @@
 @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,400italic,700);
 
+html {
+	overflow: scroll;
+}
 body {
 	background: #fff;
 	color: #455164;


### PR DESCRIPTION
This makes the page scroll always visible, so that going between pages that are short and long doesn't make the content move to left a little.

This can be seen when going from `Introduction` documentation page to another longer page.