### PR TITLE
Port recent changes to `maxHistory` from default config file

### DIFF
--- a/_docs/server/configuration.md
+++ b/_docs/server/configuration.md
@@ -179,8 +179,10 @@ logs: {
 
 ## maxHistory
 
-Defines the maximum number of history lines to keep per channel/query.
-A negative value means unlimited history. Default to `-1`.
+Defines the maximum number of history lines that will be kept in
+memory per channel/query, in order to reduce the memory usage of
+the server. Setting this to -1 will keep unlimited amount.
+Default to `10000`. 
 
 Example:
 


### PR DESCRIPTION
This was changed in https://github.com/thelounge/lounge/pull/899 and will be deployed as part of v2.2.1, so keeping this section up-to-date with it.