### PR TITLE
Add notes about moving client docs to the app itself

### DIFF
--- a/_docs/client/commands.md
+++ b/_docs/client/commands.md
@@ -1,12 +1,15 @@
 ---
 layout: documentation
 title: Commands
-description: Add your description here
 category: Client
 order: 3.1
 ---
 
 # Commands
+
+<div class="alert alert-danger" role="alert">
+  <strong>As of The Lounge v2.2.2, information presented below has been moved to the Help section of the application. This page will be removed soon.</strong>
+</div>
 
 The Lounge implements most of the IRC commands you may be familiar with. Here's a list of commands you can use:
 

--- a/_docs/client/keyboard_shortcuts.md
+++ b/_docs/client/keyboard_shortcuts.md
@@ -1,12 +1,15 @@
 ---
 layout: documentation
 title: Keyboard Shortcuts
-description: Add your description here
 category: Client
 order: 3.2
 ---
 
 # Keyboard Shortcuts
+
+<div class="alert alert-danger" role="alert">
+  <strong>As of The Lounge v2.2.2, information presented below has been moved to the Help section of the application. This page will be removed soon.</strong>
+</div>
 
 ## Switch channels
 
@@ -35,11 +38,11 @@ _This is the same as `/clear`._
 __WIN / LINUX:__
 
 ```
-CTRL + L
+CTRL + SHIFT + L
 ```
 
 __OS X:__
 
 ```
-COMMAND + L
+COMMAND + K
 ```


### PR DESCRIPTION
This also fixes the keyboard shortcuts, mis-documented for a while. At least last version before cleanup will be technically correct!

This PR goes alongside with https://github.com/thelounge/lounge/pull/941. It is still part of my documentation work :)

<img width="554" alt="screen shot 2017-03-01 at 01 05 40" src="https://cloud.githubusercontent.com/assets/113730/23447780/382bf090-fe1b-11e6-844b-948fcf94af78.png">
