### PR TITLE
Remove wrong and inexistent home option from configuration documentation

### DIFF
--- a/_docs/server/configuration.md
+++ b/_docs/server/configuration.md
@@ -154,12 +154,6 @@ Used for the WEBIRC support in The Lounge. Default to `null`.
 The Lounge then sends the connecting user's host and IP to the IRC server.
 This requires to have a password from the IRC network used.
 
-## home
-
-Use this setting to override the default `HOME` location.
-The home folder is where The Lounge will locate the `users/` and `cache/` folder.
-Leaving this field empty will default to `~/.lounge/`.
-
 ## logs
 
 Change how the logs will be stored. Remember that logging has to be


### PR DESCRIPTION
Closes https://github.com/thelounge/thelounge.github.io/issues/62.

This option has never existed, and is supposed to contain the location of the configuration file... in the configuration file itself.

I have [removed the whole thing in the new documentation](https://github.com/thelounge/thelounge.github.io/commit/f2848df1ad606279eafb902dafb1d83362389735#diff-79668e76b304ebe02151ea993a75fa46L157) but until this happens (soon™), we shouldn't leave it in there anyway.