### PR TITLE
Deprecate --home in favor of LOUNGE_HOME env var

### DIFF
--- a/_docs/getting_started/usage.md
+++ b/_docs/getting_started/usage.md
@@ -97,6 +97,10 @@ $ lounge edit john
 
 ## `--home`
 
+<div class="alert alert-danger" role="alert">
+    <strong>As of The Lounge v2.5.0, <code>--home</code> is deprecated. Use the <code>LOUNGE_HOME</code> environment variable instead.</strong>
+</div>
+
 _Set the home path. This is the location where The Lounge will look for the `config.js` and the `users/` folder._
 
 *Also configurable through the environment variable `LOUNGE_HOME`.*
@@ -104,9 +108,7 @@ _Set the home path. This is the location where The Lounge will look for the `con
 Example:
 
 ```
-$ lounge --home /app add <user>  # add user to /app/users
-$ lounge --home /app             # start server with /app/config.js
-$ LOUNGE_HOME=/app lounge        # start server with /app/config.js
+$ LOUNGE_HOME=/tmp lounge start # start server with configuration at /tmp/config.js
 ```
 
 ## `--help`


### PR DESCRIPTION
`--home` will be deprecated in v2.5.0, see https://github.com/thelounge/lounge/pull/1416.

<img width="575" alt="screen shot 2017-08-17 at 23 57 15" src="https://user-images.githubusercontent.com/113730/29443724-00b71f1e-83a8-11e7-96c8-e809816e3cc0.png">
