### PR TITLE
Set HTML `lang` attribute to help screen readers

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 	<head>
 
 	<meta charset="utf-8">


### PR DESCRIPTION
Extracted from #84.