### PR TITLE
Switch redcarpet engine to kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
 gem 'jekyll', '~> 3'
-gem 'redcarpet', '~> 3'
+gem 'kramdown', '~> 1'
 gem 'jekyll-sitemap', '~> 1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    redcarpet (3.4.0)
     rouge (3.1.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
@@ -62,7 +61,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3)
   jekyll-sitemap (~> 1)
-  redcarpet (~> 3)
+  kramdown (~> 1)
 
 BUNDLED WITH
    1.16.1

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: The Lounge &mdash; Self-hosted web IRC client
 description: "The official website for The Lounge, the self-hosted web IRC client."
 baseurl: ""
 markdown: kramdown
-gems:
+plugins:
   - jekyll-sitemap
 collections:
   docs:

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,7 @@
 title: The Lounge &mdash; Self-hosted web IRC client
 description: "The official website for The Lounge, the self-hosted web IRC client."
 baseurl: ""
-markdown: redcarpet
-redcarpet:
-  extensions: ["smart", "tables", "autolink", "with_toc_data"]
+markdown: kramdown
 gems:
   - jekyll-sitemap
 collections:


### PR DESCRIPTION
Extracted from #84.

kramdown seems more widely used (for example, GitHub Pages dropped support for redcarpet some time ago) and gives a lot more feature support out of the box. For example, this also lets us use CSS classes with `{: .my-class }`, which I use a lot in #84.