### PR TITLE
Use system font stack instead of Open Sans

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,9 +1,7 @@
-@import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,400italic,700);
-
 body {
 	background: #fff;
 	color: #455164;
-	font: 15px "Open Sans", sans-serif;
+	font: 16px -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 	margin: 0;
 	margin-bottom: 100px;
 }


### PR DESCRIPTION
This uses the same declaration as [the app's `/client/css/style.css`](https://github.com/thelounge/thelounge/blob/b0095488f906845e1a850119505e1ffa645f7e70/client/css/style.css#L50).

I am opening this PR for archive purpose but I am really not in favor of this. I am 100% in favor for the main application, but for our "marketing" website + docs, I think it looks really poor and reads harder.

Before | After
--- | ---
[Deploy Preview](https://5bd416ce3813f02d3741a5e2--thelounge.netlify.com/) | [Deploy Preview](https://deploy-preview-103--thelounge.netlify.com/)
<img width="768" alt="screen shot 2018-10-27 at 19 36 51" src="https://user-images.githubusercontent.com/113730/47610398-26d47080-da22-11e8-8dba-ee25310ca330.png"> | <img width="762" alt="screen shot 2018-10-27 at 19 36 40" src="https://user-images.githubusercontent.com/113730/47610399-26d47080-da22-11e8-8e5d-7cd6118a3a93.png">
<img width="736" alt="screen shot 2018-10-27 at 19 36 22" src="https://user-images.githubusercontent.com/113730/47610393-1de39f00-da22-11e8-9aeb-b74088117405.png"> | <img width="751" alt="screen shot 2018-10-27 at 19 36 15" src="https://user-images.githubusercontent.com/113730/47610394-1de39f00-da22-11e8-9099-08b3b2de7825.png">
