### PR TITLE
Use apt to install on Debian/Ubuntu

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -20,7 +20,7 @@ Then download `thelounge.deb` located at the bottom of
 Finally, open a terminal and install the downloaded package using:
 
 ```
-sudo dpkg --install thelounge.deb
+sudo apt install ./thelounge.deb
 ```
 
 {: .alert.alert-info role="alert"}


### PR DESCRIPTION
installing with dpkg can leave unsatisfied dependencies. apt will automatically fetch and install missing deps.