### PR TITLE
Structure doc navigation, use Netlify for redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
 
 gem 'jekyll', '3.8.4'
-gem 'jekyll-redirect-from', '0.14.0'
 gem 'jekyll-sitemap', '1.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,6 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
-    jekyll-redirect-from (0.14.0)
-      jekyll (~> 3.3)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
@@ -62,7 +60,6 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (= 3.8.4)
-  jekyll-redirect-from (= 0.14.0)
   jekyll-sitemap (= 1.2.0)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ include:
   - _headers
   - _redirects
 plugins:
-  - jekyll-redirect-from
   - jekyll-sitemap
 collections:
   docs:

--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -4,8 +4,6 @@ title: Configuration
 order: 4
 ---
 
-# Configuration
-
 This part of the documentation focuses on the configuration of the server.
 
 Start by locating the `config.js` file in the configuration folder, which

--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -2,8 +2,6 @@
 layout: documentation
 title: Configuration
 order: 4
-redirect_from:
-  - /docs/server/configuration.html
 ---
 
 # Configuration

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: documentation
 title: Introduction
-order: 0.0
+order: 1
 ---
 
 # The Lounge

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -4,8 +4,6 @@ title: Introduction
 order: 1
 ---
 
-# The Lounge
-
 Welcome to the documentation. __It's currently a work in progress.__
 
 ## Help needed

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -4,8 +4,6 @@ title: Install and upgrade
 order: 2
 ---
 
-# Install and upgrade
-
 ## Debian and Ubuntu based distributions
 
 First, make sure [Node.js](https://nodejs.org/) v6.13.0 or more recent is installed

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -2,8 +2,6 @@
 layout: documentation
 title: Install and upgrade
 order: 2
-redirect_from:
-  - /docs/getting_started/install.html
 ---
 
 # Install and upgrade

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -109,7 +109,7 @@ Note that installing from npm does not daemonize nor autostart The Lounge.
 The Lounge is now up and running **in private mode** at <http://localhost:9000>.
 
 Read more about how to use The Lounge from the command line in
-[the CLI usage section](/docs/server/usage.html).
+[the CLI usage section](/docs/usage.html).
 
 Its configuration file is located at `~/.thelounge/config.js`. To configure The
 Lounge, go to [the configuration section](/docs/configuration.html).
@@ -182,7 +182,7 @@ Note that installing from source does not daemonize nor autostart The Lounge.
 The Lounge is now up and running **in private mode** at <http://localhost:9000>.
 
 Read more about how to use The Lounge from the command line in
-[the CLI usage section](/docs/server/usage.html).
+[the CLI usage section](/docs/usage.html).
 
 Its configuration file is located at `~/.thelounge/config.js`. To configure The
 Lounge, go to [the configuration section](/docs/configuration.html).

--- a/_docs/themes.md
+++ b/_docs/themes.md
@@ -3,13 +3,13 @@ layout: documentation
 title: Themes
 ---
 
-# Finding Themes
+## Finding Themes
 
 Themes published on npm should have the keyword `thelounge-theme`, so you can
 find a list by
 [searching on npmjs.org](https://www.npmjs.com/search?q=keywords%3Athelounge-theme).
 
-# Installing Themes
+## Installing Themes
 
 To install theme `thelounge-theme-custom`:
 
@@ -17,7 +17,7 @@ To install theme `thelounge-theme-custom`:
 * Restart The Lounge
 * Select theme in options
 
-# Creating Themes
+## Creating Themes
 
 Create an npm package using the base `package.json` below, and publish to npm:
 

--- a/_docs/themes.md
+++ b/_docs/themes.md
@@ -1,8 +1,8 @@
 ---
 layout: documentation
 title: Themes
-category: Plugins
-order: 5.1
+redirect_from:
+  - /docs/plugins/themes.html
 ---
 
 # Finding Themes

--- a/_docs/themes.md
+++ b/_docs/themes.md
@@ -1,8 +1,6 @@
 ---
 layout: documentation
 title: Themes
-redirect_from:
-  - /docs/plugins/themes.html
 ---
 
 # Finding Themes

--- a/_docs/unofficial-install-methods/heroku.md
+++ b/_docs/unofficial-install-methods/heroku.md
@@ -3,8 +3,6 @@ layout: documentation
 title: Heroku
 ---
 
-# Heroku
-
 This document will explain how to install The Lounge on Heroku. To learn more
 about Heroku, read their
 [documentation](https://devcenter.heroku.com/articles/getting-started-with-nodejs#introduction).

--- a/_docs/usage.md
+++ b/_docs/usage.md
@@ -1,9 +1,9 @@
 ---
 layout: documentation
 title: Usage
-description: Add your description here
-category: Getting Started
-order: 1.2
+order: 3
+redirect_from:
+  - /docs/getting_started/install.html
 ---
 
 # Usage

--- a/_docs/usage.md
+++ b/_docs/usage.md
@@ -2,8 +2,6 @@
 layout: documentation
 title: Usage
 order: 3
-redirect_from:
-  - /docs/getting_started/install.html
 ---
 
 # Usage

--- a/_docs/usage.md
+++ b/_docs/usage.md
@@ -4,8 +4,6 @@ title: Usage
 order: 3
 ---
 
-# Usage
-
 Once you've installed The Lounge, go ahead and run:
 
 ```

--- a/_docs/users.md
+++ b/_docs/users.md
@@ -1,9 +1,9 @@
 ---
 layout: documentation
 title: Users
-description: Add your description here
-category: Server
-order: 2.2
+order: 5
+redirect_from:
+  - /docs/server/users.html
 ---
 
 # Users
@@ -25,7 +25,7 @@ $ thelounge add <name>
 
 This will create a new user in your `users/` folder.
 
-_Note: By default, users are stored in the `~/.thelounge/users/` folder. You can change this location by using the `--home <path>` setting (see [Usage](/docs/getting_started/usage.html#home))._
+_Note: By default, users are stored in the `~/.thelounge/users/` folder. You can change this location by using the `--home <path>` setting (see [Usage](/docs/usage.html#home))._
 
 ## Edit user
 

--- a/_docs/users.md
+++ b/_docs/users.md
@@ -4,8 +4,6 @@ title: Users
 order: 5
 ---
 
-# Users
-
 Once you've set up The Lounge, it's time to add your first users. Open your `config.js` and set `public` to `false`. This will enable user login.
 
 When you start The Lounge in "private" mode it will load every user found in your `users/` folder. Here's some of the features users get:

--- a/_docs/users.md
+++ b/_docs/users.md
@@ -2,8 +2,6 @@
 layout: documentation
 title: Users
 order: 5
-redirect_from:
-  - /docs/server/users.html
 ---
 
 # Users

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,10 +1,6 @@
 <div id="menu">
 	{% assign docs = (site.docs | sort: "order" ) %}
 	{% for node in docs %}
-		{% if c != node.category %}
-			{% assign c = node.category %}
-			<strong>{{ node.category }}</strong>
-		{% endif %}
 		<a href="{{ site.baseurl }}{{ node.url }}"{% if page.url == node.url %} class="active"{% endif %}>
 			{{ node.title }}
 		</a>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,8 +1,11 @@
 <div id="menu">
 	{% assign docs = (site.docs | sort: "order" ) %}
 	{% for node in docs %}
-		<a href="{{ site.baseurl }}{{ node.url }}"{% if page.url == node.url %} class="active"{% endif %}>
-			{{ node.title }}
-		</a>
+		{% assign level = (node.relative_path | split: '/' | size) %}
+		{% if level == 2 # Not a subfolder %}
+			<a href="{{ site.baseurl }}{{ node.url }}"{% if page.url == node.url %} class="active"{% endif %}>
+				{{ node.title }}
+			</a>
+		{% endif %}
 	{% endfor %}
 </div>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -9,6 +9,8 @@ layout: default
 				{% include menu.html %}
 			</aside>
 			<div class="col-sm-9 content">
+				<h1>{{ page.title }}</h1>
+
 				{{ content }}
 			</div>
 		</div>

--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,18 @@
+## Archived redirects during the v2 to v3 documentation transition
+
+/docs/getting_started/install    /docs/install_and_upgrade
+/docs/getting_started/usage      /docs/usage
+
+/docs/server/configuration       /docs/configuration
+/docs/server/users               /docs/users
+
 # Client-related documentations have been moved to the Help window of the
 # application itself since v2.2.2.
 /docs/client/commands            https://demo.thelounge.chat/#help  302
 /docs/client/keyboard_shortcuts  https://demo.thelounge.chat/#help  302
+
+/docs/deployment/docker          /docs/install-and-upgrade#docker
+/docs/deployment/heroku          /docs/unofficial-install-methods/heroku
+/docs/deployment/passenger       /docs/guides/reverse-proxies
+
+/docs/plugins/themes             /docs/guides/authoring-themes


### PR DESCRIPTION
Extracted from #84.

(Don't worry about the "Themes" entry still showing up, it's taken care of as part of incoming guide about themes)