### PR TITLE
Add syntax highlighting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -471,3 +471,37 @@ a.link-anchor {
 	color: white;
 	font-weight: bold;
 }
+
+/* Rouge syntax highlighting - Igorpro theme */
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight, .highlight .w {
+  color: #444444;
+}
+.highlight .cp {
+  color: #CC00A3;
+}
+.highlight .cs {
+  color: #CC00A3;
+}
+.highlight .c, .highlight .cd, .highlight .cm, .highlight .c1 {
+  color: #FF0000;
+}
+.highlight .kc {
+  color: #C34E00;
+}
+.highlight .kd {
+  color: #0000FF;
+}
+.highlight .kr {
+  color: #007575;
+}
+.highlight .k, .highlight .kn, .highlight .kp, .highlight .kt, .highlight .kv {
+  color: #0000FF;
+}
+.highlight .s, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .s2, .highlight .se, .highlight .sh, .highlight .si, .highlight .sx, .highlight .sr, .highlight .s1, .highlight .ss {
+  color: #009C00;
+}
+.highlight .nb, .highlight .bp {
+  color: #C34E00;
+}


### PR DESCRIPTION
Extracted from #84.

This is going to be helpful for guides such as #119. See [this](https://deploy-preview-84--thelounge.netlify.com/docs/guides/reverse-proxies#nginx) for example.