### PR TITLE
Do not markdownify titles as it wraps them in paragraph

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -9,7 +9,7 @@ layout: default
 				{% include menu.html %}
 			</aside>
 			<div class="col-sm-9 content">
-				<h1>{{ page.title | markdownify }}</h1>
+				<h1>{{ page.title }}</h1>
 
 				{{ content }}
 			</div>


### PR DESCRIPTION
At the moment, this is not a big deal because only one (future) guide is affected, but if that ends up being an issue, we can always do [this thing](https://github.com/jekyll/jekyll/issues/3571#issuecomment-372061718).