### PR TITLE
Make internal links extension-less and fix a few links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,10 @@ plugins:
 collections:
   docs:
     output: true
+    permalink: /:collection/:path
   api:
     output: true
-    permalink: /docs/:collection/:path:output_ext
+    permalink: /docs/:collection/:path
   guides:
     output: true
-    permalink: /docs/:collection/:path:output_ext
+    permalink: /docs/:collection/:path

--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -7,7 +7,7 @@ order: 4
 This part of the documentation focuses on the configuration of the server.
 
 Start by locating the `config.js` file in the configuration folder, which
-depends on how you [installed The Lounge](/docs/install-and-upgrade.html).
+depends on how you [installed The Lounge](/docs/install-and-upgrade).
 
 {% include toc.md %}
 

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -6,7 +6,7 @@ order: 1
 
 Welcome to The Lounge, a web-based [IRC](https://en.wikipedia.org/wiki/Internet_Relay_Chat) client for the modern world! ❤️
 
-For an optimal experience, The Lounge must be installed on a server that runs 24/7. Once configured and started, users can access it from their browser or mobile device. Learn more about this in the [install and upgrade section](/docs/install-and-upgrade.html).
+For an optimal experience, The Lounge must be installed on a server that runs 24/7. Once configured and started, users can access it from their browser or mobile device. Learn more about this in the [install and upgrade section](/docs/install-and-upgrade).
 
 **In private mode**, The Lounge acts like a bouncer and a client combined, in order to offer an experience similar to other modern chat applications outside the IRC world. Users can then access and resume their session without being disconnected from their channels.
 

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -30,14 +30,14 @@ control with `systemctl status|start|restart|stop|...`.
 The Lounge is now up and running **in private mode** at <http://localhost:9000>.
 
 Its configuration file is located at `/etc/thelounge/config.js`. To configure
-The Lounge, go to [the configuration section](/docs/configuration.html).
+The Lounge, go to [the configuration section](/docs/configuration).
 
 To upgrade The Lounge, simply follow these steps again after downloading a new
 `thelounge.deb` file, and restart the service.
 
 You might want to serve The Lounge behind a reverse proxy such as Nginx. To know
 more about the benefits and steps, follow
-[the guide on reverse proxies ](/docs/guides/reverse-proxies.html).
+[the guide on reverse proxies](/docs/guides/reverse-proxies).
 
 ## Arch Linux
 
@@ -72,11 +72,11 @@ service:
   your home directory in `~/.thelounge/config.js`.
 
 To configure The Lounge, go to
-[the configuration section](/docs/configuration.html).
+[the configuration section](/docs/configuration).
 
 You might want to serve The Lounge behind a reverse proxy such as Nginx. To know
 more about the benefits and steps, follow
-[the guide on reverse proxies](/docs/guides/reverse-proxies.html).
+[the guide on reverse proxies](/docs/guides/reverse-proxies).
 
 ## From npm releases
 
@@ -107,16 +107,16 @@ Note that installing from npm does not daemonize nor autostart The Lounge.
 The Lounge is now up and running **in private mode** at <http://localhost:9000>.
 
 Read more about how to use The Lounge from the command line in
-[the CLI usage section](/docs/usage.html).
+[the CLI usage section](/docs/usage).
 
 Its configuration file is located at `~/.thelounge/config.js`. To configure The
-Lounge, go to [the configuration section](/docs/configuration.html).
+Lounge, go to [the configuration section](/docs/configuration).
 
 To upgrade The Lounge, simply re-run the `install` command above, and restart it.
 
 You might want to serve The Lounge behind a reverse proxy such as Nginx. To know
 more about the benefits and steps, follow
-[the guide on reverse proxies ](/docs/guides/reverse-proxies.html).
+[the guide on reverse proxies](/docs/guides/reverse-proxies).
 
 ## Docker
 
@@ -180,17 +180,17 @@ Note that installing from source does not daemonize nor autostart The Lounge.
 The Lounge is now up and running **in private mode** at <http://localhost:9000>.
 
 Read more about how to use The Lounge from the command line in
-[the CLI usage section](/docs/usage.html).
+[the CLI usage section](/docs/usage).
 
 Its configuration file is located at `~/.thelounge/config.js`. To configure The
-Lounge, go to [the configuration section](/docs/configuration.html).
+Lounge, go to [the configuration section](/docs/configuration).
 
 To upgrade The Lounge, simply `git pull` the repository, re-run the `install` and
 `build` commands above, and restart it.
 
 You might want to serve The Lounge behind a reverse proxy such as Nginx. To know
 more about the benefits and steps, follow
-[the guide on reverse proxies ](/docs/guides/reverse-proxies.html).
+[the guide on reverse proxies](/docs/guides/reverse-proxies).
 
 ## Unofficial install methods
 
@@ -198,7 +198,7 @@ Over time, people have come up with recipes to install The Lounge on different
 setups and platforms, with different tooling, etc. These are not officially
 supported (even when hosted on this website), so use them at your own risk:
 
-- [Install on Heroku](/docs/unofficial-install-methods/heroku.html)
+- [Install on Heroku](/docs/unofficial-install-methods/heroku)
 - [OpenShift Online recipe](https://github.com/pacbard/openshift-thelounge)
 - [Ansible role using Supervisor](https://github.com/astorije/ansible-lounge)
 - [ARMHF Docker images](https://hub.docker.com/r/lsioarmhf/thelounge/)

--- a/_docs/usage.md
+++ b/_docs/usage.md
@@ -67,12 +67,12 @@ This tells us a few things:
 
 - Since it is the first time The Lounge runs, a configuration file was created.
   Its location depends on how The Lounge was installed (see
-  [the installation page](/docs/install-and-upgrade.html)).
+  [the installation page](/docs/install-and-upgrade)).
 - The Lounge can now be accessed at <http://localhost:9000/>.
 - It has started in **private** mode, which means only users who
   have an account can log in. There is no guest access.
 - There are no user accounts as of yet, so in fact, no one can log in for now
-  (see the [user management](http://localhost:4000/docs/users.html) page).
+  (see the [user management](/docs/users) page).
 
 The process can be stopped at any time by hitting <kbd>Ctrl</kbd>+<kbd>C</kbd>.
 This will effectively close all connections to remote IRC servers that users are
@@ -105,7 +105,7 @@ thelounge install thelounge-theme-solarized
 
 After restarting The Lounge, the theme will now be available in the client settings.
 
-Additionally, any theme can be used as the default one for all clients. See [the `theme` section on the configuration page](/docs/configuration.html) for more information.
+Additionally, any theme can be used as the default one for all clients. See [the `theme` section on the configuration page](/docs/configuration) for more information.
 
 ## Configuring The Lounge
 
@@ -135,7 +135,7 @@ thelounge start -c port=9001 -c public=true
 
 However, `--config` is not limited to setting the port or mode. In fact, any
 option available in the configuration file can be passed using `--config`.
-See the [configuration page](/docs/configuration.html) for a full list.
+See the [configuration page](/docs/configuration) for a full list.
 
 A few rules apply to the `--config` option:
 

--- a/_docs/users.md
+++ b/_docs/users.md
@@ -4,7 +4,7 @@ title: Users
 order: 5
 ---
 
-In [private mode](/docs/configuration.html#public), only authorized users can access and use The Lounge.
+In [private mode](/docs/configuration#public), only authorized users can access and use The Lounge.
 
 All user configurations are stored as JSON files in the `${THELOUNGE_HOME}/users/` folder. These are being read upon server startup to connect users to their IRC networks and channels.
 

--- a/_guides/https.md
+++ b/_guides/https.md
@@ -6,7 +6,7 @@ title: Protect The Lounge with HTTPS
 In this guide, we will see how to easily configure The Lounge to be served over [HTTPS](https://en.wikipedia.org/wiki/HTTPS) for better security and privacy.
 
 {: .alert.alert-warning role="alert"}
-The Lounge only has basic HTTPS support, and will need to be manually restarted to reload certificates on renewal. For advanced HTTPS support, consider [using a reverse proxy](/docs/guides/reverse-proxies.html).
+The Lounge only has basic HTTPS support, and will need to be manually restarted to reload certificates on renewal. For advanced HTTPS support, consider [using a reverse proxy](/docs/guides/reverse-proxies).
 
 First, you need an HTTPS certificate. [Let's Encrypt](https://letsencrypt.org/) is a free, automated, and open Certificate Authority that provides completely free HTTPS certificates.
 

--- a/_guides/network-overrides.md
+++ b/_guides/network-overrides.md
@@ -20,7 +20,7 @@ The following URL parameters can be used to override the fields of the Connect f
 - `realname`
 - `join` or `channels`
 
-Note that when [the `lockNetwork` setting](/docs/configuration.html#locknetwork) is set to `true`, the keys `host`, `port`, and `rejectUnauthorized` have no effect. When [the `displayNetwork` setting](/docs/configuration.html#displaynetwork) is set to `false`, the `name` key has no effect.
+Note that when [the `lockNetwork` setting](/docs/configuration#locknetwork) is set to `true`, the keys `host`, `port`, and `rejectUnauthorized` have no effect. When [the `displayNetwork` setting](/docs/configuration#displaynetwork) is set to `false`, the `name` key has no effect.
 
 When using the comma-separated `join` or `channels` keys, alphanumeric sequences will be prefixed with `#`. For example, `?join=foo` fills the form field with
 `#foo`.

--- a/_guides/theme-creation.md
+++ b/_guides/theme-creation.md
@@ -46,5 +46,5 @@ module.exports = {
     name: "Theme Name",
     type: "theme"
   }
-}
+};
 ```

--- a/_includes/config.js.md
+++ b/_includes/config.js.md
@@ -63,7 +63,7 @@ This value is set to `10000` by default.
 These settings are used to run The Lounge's web server using encrypted TLS.
 
 If you want more control over the webserver,
-[use a reverse proxy instead](https://thelounge.chat/docs/guides/reverse-proxies.html).
+[use a reverse proxy instead](https://thelounge.chat/docs/guides/reverse-proxies).
 
 The available keys for the `https` object are:
 
@@ -85,7 +85,7 @@ different one in their client settings among those available.
 
 The Lounge ships with two themes (`default` and `morning`) and can be
 extended by installing more themes. Read more about how to manage them
-[here](https://thelounge.chat/docs/plugins/themes.html).
+[here](https://thelounge.chat/docs/plugins/themes).
 
 This value needs to be the package name and not the display name. For
 example, the value for Morning would be `morning`, and the value for

--- a/js/search_data.js
+++ b/js/search_data.js
@@ -4,7 +4,7 @@ window.search_data = {
   {%- assign documents = site.documents | concat: site.pages %}
   {%- for document in documents %}
   {%- unless document.title %}{% continue %}{% endunless %}
-  "{{ document.url }}": {
+  "{{ document.url | remove: ".html" }}": {
     "title": "{{ document.title | xml_escape }}",
     "category": "{{ document.category | xml_escape }}",
     "content": {{ document.content | newline_to_br | strip_newlines | replace: "<br />", " " | strip_html | jsonify }}


### PR DESCRIPTION
Extracted from #84.

This is _mostly_ handled by Netlify already, which "prettifies" the URLs, but that way this is consistent in dev and prod. Jekyll supports extension-less just fine.

"_Mostly_" because this is not the case for URLs generated from the search results for example, obviously.