### PR TITLE
Prevent redirect from /docs to /docs/ (forced with !)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,8 @@
+# Spares an extra 301 when loading `/docs` which originally redirects to `/docs/`
+# `!` is required to force the rewrite despite the matching. See
+# https://www.netlify.com/docs/redirects/#note-on-shadowing
+/docs  /docs/index  200!
+
 ## Archived redirects during the v2 to v3 documentation transition
 
 /docs/getting_started/install    /docs/install-and-upgrade


### PR DESCRIPTION
Attempt at resolving #165, alternative to #167.

I am not 100% sure that this is going to work, but according to their docs it should. I should be able to test on the deploy preview.

I'd prefer doing nothing over this, but I'd prefer doing this over adding a slash in the navbar link, which in turn I'd prefer over moving the docs page at the root :)