### PR TITLE
Disallow robots in non-production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source "https://rubygems.org"
 
 gem 'jekyll', '3.8.4'
-gem 'jekyll-sitemap', '1.2.0'
+
+group :jekyll_plugins do
+  gem 'jekyll-netlify', '0.2.0'
+  gem 'jekyll-sitemap', '1.2.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-netlify (0.2.0)
+      jekyll (~> 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-sitemap (1.2.0)
@@ -60,6 +62,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (= 3.8.4)
+  jekyll-netlify (= 0.2.0)
   jekyll-sitemap (= 1.2.0)
 
 BUNDLED WITH

--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,6 @@ include:
 kramdown:
   toc_levels: "2"
 url: https://thelounge.chat # Domain used by jekyll-sitemap in sitemap.xml
-plugins:
-  - jekyll-sitemap
 permalink: /:path
 collections:
   docs:

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,7 @@
+---
+---
+
 User-Agent: *
-Allow: /
-Sitemap: https://thelounge.chat/sitemap.xml
+{% if jekyll.environment == "production" %}Allow: /{% else %}Disallow: /{% endif %}
+Sitemap: {{ site.url }}/sitemap.xml
 Host: thelounge.chat

--- a/robots.txt
+++ b/robots.txt
@@ -2,6 +2,6 @@
 ---
 
 User-Agent: *
-{% if jekyll.environment == "production" %}Allow: /{% else %}Disallow: /{% endif %}
+{% if site.netlify.context == "production" %}Allow: /{% else %}Disallow: /{% endif %}
 Sitemap: {{ site.url }}/sitemap.xml
 Host: thelounge.chat


### PR DESCRIPTION
Fixes #172. Got the example from https://github.com/twbs/bootstrap/blob/110c7f4cc0c5693583e0e69bdde3465c934b6e58/site/robots.txt

The question is: does netlify actually set `environment: production` when building for production/master?