### PR TITLE
Do not link to language-specific URL of Yarn to let them redirect to the correct language

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -84,7 +84,7 @@ Installing the [npm package](https://www.npmjs.com/package/thelounge) directly
 allows you to use stable releases on systems where we do not provide native
 packages.
 
-First, make sure [Node.js](https://nodejs.org/) v6.13.0 (or more recent) and [Yarn](https://yarnpkg.com/) are installed on your system. See [official instructions for Node.js](https://nodejs.org/en/download/package-manager/) and [official instructions for Yarn](https://yarnpkg.com/en/docs/install).
+First, make sure [Node.js](https://nodejs.org/) v6.13.0 (or more recent) and [Yarn](https://yarnpkg.com/) are installed on your system. See [official instructions for Node.js](https://nodejs.org/en/download/package-manager/) and [official instructions for Yarn](https://yarnpkg.com/docs/install).
 
 Then install The Lounge using:
 
@@ -156,7 +156,7 @@ may be unstable or insecure. This is not production-ready, so use at your own
 risk!<br>
 It is also not recommended to run this as a `root` user.
 
-First, make sure [Node.js](https://nodejs.org/) v6.13.0 (or more recent) and [Yarn](https://yarnpkg.com/) are installed on your system. See [official instructions for Node.js](https://nodejs.org/en/download/package-manager/) and [official instructions for Yarn](https://yarnpkg.com/en/docs/install).
+First, make sure [Node.js](https://nodejs.org/) v6.13.0 (or more recent) and [Yarn](https://yarnpkg.com/) are installed on your system. See [official instructions for Node.js](https://nodejs.org/en/download/package-manager/) and [official instructions for Yarn](https://yarnpkg.com/docs/install).
 
 The following commands install the development version of The Lounge:
 


### PR DESCRIPTION
```
$ curl -I https://yarnpkg.com/docs/install
HTTP/2 302
location: /en/docs/install

$ curl -I -H 'Accept-Language: fr' https://yarnpkg.com/docs/install
HTTP/2 302
location: /fr/docs/install/
```