### PR TITLE
Add X-Forwarded-Proto to reverse proxy configs

### DIFF
--- a/_guides/reverse-proxies.md
+++ b/_guides/reverse-proxies.md
@@ -52,7 +52,7 @@ gzip_types application/javascript image/svg+xml text/css text/plain;
 
 ## [Apache](https://httpd.apache.org/)
 
-Enable the necessary modules `a2enmod rewrite`, `a2enmod proxy`, `a2enmod proxy_http`, `a2enmod headers`, and `a2enmod proxy_wstunnel`.
+Enable the necessary modules `a2enmod rewrite`, `a2enmod proxy`, `a2enmod proxy_http`, and `a2enmod proxy_wstunnel`.
 
 This makes The Lounge available at `https://example.com/irc/`:
 

--- a/_guides/reverse-proxies.md
+++ b/_guides/reverse-proxies.md
@@ -32,6 +32,7 @@ location ^~ /irc/ {
 	proxy_set_header Connection "upgrade";
 	proxy_set_header Upgrade $http_upgrade;
 	proxy_set_header X-Forwarded-For $remote_addr;
+	proxy_set_header X-Forwarded-Proto $scheme;
 
 	# by default nginx times out connections in one minute
 	proxy_read_timeout 1d;
@@ -51,7 +52,7 @@ gzip_types application/javascript image/svg+xml text/css text/plain;
 
 ## [Apache](https://httpd.apache.org/)
 
-Enable the necessary modules `a2enmod rewrite`, `a2enmod proxy`, `a2enmod proxy_http`, and `a2enmod proxy_wstunnel`.
+Enable the necessary modules `a2enmod rewrite`, `a2enmod proxy`, `a2enmod proxy_http`, `a2enmod headers`, and `a2enmod proxy_wstunnel`.
 
 This makes The Lounge available at `https://example.com/irc/`:
 
@@ -64,6 +65,7 @@ RewriteRule /irc/(.*)       ws://127.0.0.1:9000/$1 [P,L]
 
 ProxyVia On
 ProxyRequests Off
+ProxyAddHeaders On
 ProxyPass /irc/ http://127.0.0.1:9000/
 ProxyPassReverse /irc/ http://127.0.0.1:9000/
 
@@ -78,6 +80,7 @@ This makes The Lounge available at `https://example.com/irc/`:
 ```
 proxy /irc/ http://127.0.0.1:9000 {
 	header_upstream X-Forwarded-For {remote}
+	header_upstream X-Forwarded-Proto {scheme}
 	without /irc/
 	websocket
 }
@@ -90,6 +93,8 @@ This makes The Lounge available at https://thelounge.example.com:
 ```
 frontend  main
 	bind *:1000
+	option forwardfor
+	http-request set-header X-Forwarded-Proto https if { ssl_fc }
 	acl thelounge_site   hdr(host)  thelounge.example.com
 	use_backend thelounge       if thelounge_site
 


### PR DESCRIPTION
We will eventually want to make use of `X-Forwarded-Proto` to detect secure connections all the way through.