### PR TITLE
Add very minimal google analytics script

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -148,3 +148,45 @@ window.search_data_loaded = function (search_data) {
 		e.preventDefault();
 	}, false);
 })();
+
+// Very miniminal Google Analytics reporting, which respects do not track, anonymous ip, and
+// basically just sends the page view, without any extra information like screen size, etc.
+(function(trackingId) {
+	if (navigator.doNotTrack === "1") {
+		return;
+	}
+
+	const serialize = (obj) => {
+		const str = [];
+
+		for (const p in obj) {
+			if (obj.hasOwnProperty(p)) {
+				if (obj[p] !== undefined) {
+					str.push(encodeURIComponent(p) + "=" + encodeURIComponent(obj[p]));
+				}
+			}
+		}
+
+		return str.join("&");
+	};
+
+	const url = "https://www.google-analytics.com/collect";
+	const data = serialize({
+		v: 1,
+		aip: 1,
+		tid: trackingId,
+		t: "pageview",
+		ds: "web",
+		dr: document.referrer || undefined,
+		dl: document.location.origin + document.location.pathname + document.location.search,
+		ul: (navigator.language || "").toLowerCase(),
+	});
+
+	if (navigator.sendBeacon) {
+		navigator.sendBeacon(url, data);
+	} else {
+		const xhr = new XMLHttpRequest();
+		xhr.open("POST", url, true);
+		xhr.send(data);
+	}
+})("UA-131399702-1");


### PR DESCRIPTION
Based on https://minimalanalytics.com/

The main purpose is to track page views and referrals so we monitor that and make some decisions.

This script does nothing if Do Not Track is enabled. anonymous ip param is also set.

The site previously loaded fonts from Google (going back to Shout), so in that sense not a lot has changed.