### PR TITLE
Update config location for .deb installations

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -29,7 +29,7 @@ control with `systemctl status|start|restart|stop|...`.
 
 The Lounge is now up and running **in private mode** at <http://localhost:9000>.
 
-Its configuration file is located at `/etc/thelounge/config.js`. To configure
+Its configuration file is located at `/etc/lounge/config.js`. To configure
 The Lounge, go to [the configuration section](/docs/configuration).
 
 To upgrade The Lounge, simply follow these steps again after downloading a new


### PR DESCRIPTION
After installing 2.7.1 from the .deb on the [Releases page](https://github.com/thelounge/thelounge/releases/tag/v2.7.1) the configuration files were installed to `/etc/lounge`, not `/etc/thelounge`.