### PR TITLE
Simplify Caddy reverse proxy example by using "transparent" shorthand

### DIFF
--- a/_guides/reverse-proxies.md
+++ b/_guides/reverse-proxies.md
@@ -93,8 +93,7 @@ ProxyTimeout 86400 # 1 day
 
 ```
 proxy / http://127.0.0.1:9000 {
-	header_upstream X-Forwarded-For {remote}
-	header_upstream X-Forwarded-Proto {scheme}
+	transparent
 	websocket
 }
 ```


### PR DESCRIPTION
Instead of manually adding headers, one can use the `transparent` shorthand. This is equivalent to 
```
header_upstream Host {host}
header_upstream X-Real-IP {remote}
header_upstream X-Forwarded-For {remote}
header_upstream X-Forwarded-Proto {scheme}
```
which is a superset of the current configuration while being shorter and clearer.

https://caddyserver.com/docs/proxy
