### PR TITLE
Remove h1 from search results

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -67,7 +67,7 @@
 	</nav>
 
 	<div id="search-results" class="container">
-		<h1>Search results</h1>
+		<div id="search-results-header">Search results</div>
 		<div id="results-placeholder"></div>
 		<div id="accessible-search-summary" aria-live="assertive" class="sr-only"></div>
 	</div>

--- a/css/style.css
+++ b/css/style.css
@@ -210,6 +210,11 @@ img {
 	margin-left: 0;
 	padding-left: 0;
 }
+#search-results-header {
+	font-size: 2em;
+	font-weight: bold;
+	margin-top: 0.67em;
+}
 
 #nav .logo img {
 	height: 100%;


### PR DESCRIPTION
There should be only one h1 tag on the page.