### PR TITLE
Apply `word-break` to `<code>` only on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,7 +71,6 @@ code {
 	border-radius: 3px;
 	font-size: 0.9em;
 	padding: 2px 4px;
-	word-break: break-all;
 }
 pre {
 	background: #f5f5f5;
@@ -390,6 +389,9 @@ img {
 	}
 	#share {
 		padding-top: 10px;
+	}
+	code {
+		word-break: break-all;
 	}
 }
 @media (max-width: 480px) {


### PR DESCRIPTION
It looks silly otherwise:

![03-205873727](https://user-images.githubusercontent.com/613331/52182587-2dd00380-2807-11e9-8d49-ee91284be9ec.png)
