### PR TITLE
add warning about using the correct user to usage.md

### DIFF
--- a/_docs/usage.md
+++ b/_docs/usage.md
@@ -37,6 +37,13 @@ If you need to check which version of The Lounge is installed, use:
 thelounge version
 ```
 
+## Using the correct system user
+
+Note that all commands **must** be executed as the same user The Lounge will be run as.
+
+### Unix like systems:
+If you installed The Lounge via the package manager of your distro and plan to run it as a system service, the user is called "thelounge". So every command needs to be executed as `sudo -u thelounge thelounge <command>`, where `<command>` should be substituted with a subcommand like `start` or `add`
+
 ## Starting the server
 
 To start the server, run the following command:

--- a/_docs/usage.md
+++ b/_docs/usage.md
@@ -41,8 +41,7 @@ thelounge version
 
 Note that all commands **must** be executed as the same user The Lounge will be run as.
 
-### Unix like systems:
-If you installed The Lounge via the package manager of your distro and plan to run it as a system service, the user is called "thelounge". So every command needs to be executed as `sudo -u thelounge thelounge <command>`, where `<command>` should be substituted with a subcommand like `start` or `add`
+If you installed The Lounge via the package manager on a unix like system and plan to run it as a system service, the user is called "thelounge". So every command needs to be executed as `sudo -u thelounge thelounge <command>`, where `<command>` should be substituted with a subcommand like `start` or `add`
 
 ## Starting the server
 


### PR DESCRIPTION
Users frequently forget / don't know that they need to run the configuration commands with the user they intend to run The Lounge as.

Add a section that explains this.

This is probably a tad rough, but I'm not sure how extensive this needs to be?