### PR TITLE
reword note on daemonizing when installing from npm

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -102,7 +102,7 @@ thelounge start
 ```
 
 {: .alert.alert-info role="alert"}
-Note that installing from npm does not daemonize nor autostart The Lounge.
+Note that installing from npm or yarn does not daemonize nor autostart The Lounge.
 
 The Lounge is now up and running **in private mode** at <http://localhost:9000>.
 


### PR DESCRIPTION
the current note's wording and placement makes it sound like installing
from yarn *does* daemonize / autostart The Lounge.
That's not true; this addition should clarify it.