### PR TITLE
Change the IRC server to Libera.Chat

### DIFF
--- a/_docs/index.md
+++ b/_docs/index.md
@@ -19,6 +19,6 @@ The Lounge is entirely free and open source. Its source code lives in a [GitHub 
 
 The Lounge started as a fork of [Shout](https://github.com/erming/shout), authored by **[Mattias Erming](https://github.com/erming)**. We owe him a lot and thank him very much for his work!
 
-Enjoy The Lounge, and make sure to join us on our **official Freenode channel `#thelounge`**!
+Enjoy The Lounge, and make sure to join us on our **official Libera.Chat channel `#thelounge`**!
 
 {% include abbreviations.md %}

--- a/_includes/config.js.md
+++ b/_includes/config.js.md
@@ -201,12 +201,12 @@ The available keys for the `defaults` object are:
 - `join`: Comma-separated list of channels to auto-join once connected.
 
 This value is set to connect to the official channel of The Lounge on
-Freenode by default:
+Libera.Chat by default:
 
 ```js
 defaults: {
-  name: "Freenode",
-  host: "chat.freenode.net",
+  name: "Libera.Chat",
+  host: "irc.libera.chat",
   port: 6697,
   password: "",
   tls: true,

--- a/community.md
+++ b/community.md
@@ -7,7 +7,7 @@ title: Community
 
 ## IRC channels
 
-If you need help, or want to help others by answering questions they might have, `#thelounge` is our official IRC channel on [Freenode](https://freenode.net/) (`chat.freenode.net:6697` on a secure connection).
+If you need help, or want to help others by answering questions they might have, `#thelounge` is our official IRC channel on [Libera.Chat](https://libera.chat/) (`irc.libera.chat:6697` on a secure connection).
 
 {:.center}
 [Click here to join it using our demo](https://demo.thelounge.chat/?join=thelounge)


### PR DESCRIPTION
I changed all references from Freenode to Libera.Chat due to the main channel being moved to the Libera.Chat network.