### PR TITLE
Update https.md

### DIFF
--- a/_guides/https.md
+++ b/_guides/https.md
@@ -9,22 +9,31 @@ In this guide, we will see how to easily configure The Lounge to be served over 
 {: .alert.alert-warning role="alert"}
 The Lounge only has basic HTTPS support, and will need to be manually restarted to reload certificates on renewal. For advanced HTTPS support, consider [using a reverse proxy](/docs/guides/reverse-proxies).
 
-First, you need an HTTPS certificate. [Let's Encrypt](https://letsencrypt.org/) is a free, automated, and open Certificate Authority that provides completely free HTTPS certificates.
+First, you need an HTTPS certificate and a domain. Make sure your domain's A record pointing to your server's IP. [Let's Encrypt](https://letsencrypt.org/) is a free, automated, and open Certificate Authority that provides completely free HTTPS certificates.
 
-Assuming you have a valid email address at `email@example.com`, and want to serve The Lounge at `https://thelounge.example.com`, run these commands on your server:
+Assuming your domain is `thelounge.example.com`, follow these steps:
 
+1. Install nginx with `sudo apt install nginx`.
+2. Create configuration file for your domain with `sudo nano /etc/nginx/sites-available/thelounge.example.com`
+3. Paste code below:
 ```
-git clone https://github.com/letsencrypt/letsencrypt
-cd letsencrypt/
-./letsencrypt-auto certonly --standalone --email email@example.com -d thelounge.example.com
+server {
+    listen 80;
+    server_name thelounge.example.com;
+
+    location / {
+        proxy_set_header   X-Forwarded-For $remote_addr;
+        proxy_set_header   Host $http_host;
+        proxy_pass         "http://127.0.0.1:9000";
+    }
+}
 ```
-
-Follow the instructions on screen. This should generate a private key, as well as your HTTPS certificate that will expire after 90 days.
-
-Open your configuration file, located at `${THELOUNGE_HOME}/config.js` and look for the `https` key, and set the following values:
-
-- Change `enable` to `true`
-- Set `key` to the private key path that was generated, `privkey.pem`
-- Set `certificate` to the certificate path, `fullchain.pem`
-
-Let's Encrypt will create its `/etc/letsencrypt` folder as root user, so you might have to change the owner of these files to the user that runs The Lounge.
+4. Save and close the file.
+5. Enable the configuration file with `sudo ln -s /etc/nginx/sites-available/thelounge.example.com /etc/nginx/sites-enabled/thelounge.example.com`
+6. Check the configuration file for errors with `sudo nginx -t`
+7. If there's no errors, restart nginx with `sudo systemctl restart nginx`
+8. Next, install certbot with `sudo apt install certbot python3-certbot-nginx`
+9. Start creating SSL certificate with `sudo certbot --nginx -d thelounge.example.com`
+10. Enter your valid email and agree to Let's Encrypt's TOS.
+11. Enter `2` to automatically redirect traffic to HTTPS
+12. Test your secured The Lounge installation by going to `https://thelounge.example.com`


### PR DESCRIPTION
Previous version of tutorial is outdated because certbot-auto is deprecated.

_I forgot to say you don't need to restart The Lounge after certificate renewal. :/_
_Tested on Ubuntu 20.04 VPS. Hence `apt` is my package manager._