### PR TITLE
Protect The Lounge with HTTPS #243 PR

### DIFF
--- a/_guides/https.md
+++ b/_guides/https.md
@@ -11,13 +11,7 @@ The Lounge only has basic HTTPS support, and will need to be manually restarted 
 
 First, you need an HTTPS certificate. [Let's Encrypt](https://letsencrypt.org/) is a free, automated, and open Certificate Authority that provides completely free HTTPS certificates.
 
-For Example:
-```
-apt-get install certbot
-certbot certonly --standalone --email email@example.com -d thelounge.example.com
-```
-
-**Please Visit**: https://certbot.eff.org/ on how to correctly generate your free SSL certificate as the above is an example.
+**Visit**: [Certbot Guide](https://certbot.eff.org/) on how to correctly generate your free SSL certificate for each operating system.
 
 This should generate a private key, as well as your HTTPS certificate that will expire after 90 days.
 


### PR DESCRIPTION
As per issue #243 the guide is out of date and I updated it with the new url for certbot guide for generated SSL certificates.  

certbot.eff.org is the offical process for generating them now as far as I can see.

Any help on wording is more than welcome.