### PR TITLE
Fix Apache configuration syntax

### DIFF
--- a/_guides/reverse-proxies.md
+++ b/_guides/reverse-proxies.md
@@ -82,8 +82,9 @@ ProxyAddHeaders On
 ProxyPass / http://127.0.0.1:9000/
 ProxyPassReverse / http://127.0.0.1:9000/
 
-# By default Apache times out connections after one minute
-ProxyTimeout 86400 # 1 day
+# By default Apache times out connections after one minute,
+# set to 86400 seconds (1 day) instead
+ProxyTimeout 86400
 ```
 
 If you want to access The Lounge in a sub folder, use the following configuration:


### PR DESCRIPTION
Apache does not support comments on the same line as a configuration directive: https://httpd.apache.org/docs/current/configuring.html#syntax

> Lines that begin with the hash character "#" are considered comments, and are ignored. Comments may **not** be included on the same line as a configuration directive. 

Fixes the following error:

> AH00526: Syntax error on line 123 of /path/to/site.conf:
> ProxyTimeout takes one argument, Set the timeout (in seconds) for a proxied connection. This overrides the server timeout