### PR TITLE
Be more explicit about needing Yarn 1 (Classic)

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -97,8 +97,8 @@ packages.
 
 First, make sure you have these installed on your system:
 
-- Latest [Node.js](https://nodejs.org/) LTS version (or latest current release). See [official installation instructions](https://nodejs.org/en/download/package-manager/).
-- [Yarn 1 (Classic)](https://legacy.yarnpkg.com/). See [official installation instructions](https://legacy.yarnpkg.com/docs/install).
+- The latest [Node.js](https://nodejs.org/) LTS version (or latest current release). See the [official installation instructions](https://nodejs.org/en/download/package-manager/).
+- [Yarn 1 (classic)](https://legacy.yarnpkg.com/). See [official installation instructions](https://legacy.yarnpkg.com/docs/install).
 
 Then install The Lounge using:
 

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -95,7 +95,10 @@ Installing the [npm package](https://www.npmjs.com/package/thelounge) directly
 allows you to use stable releases on systems where we do not provide native
 packages.
 
-First, make sure latest [Node.js](https://nodejs.org/) LTS version (or latest current release) and [Yarn](https://legacy.yarnpkg.com/) are installed on your system. See [official instructions for Node.js](https://nodejs.org/en/download/package-manager/) and [official instructions for Yarn](https://legacy.yarnpkg.com/docs/install).
+First, make sure you have these installed on your system:
+
+- Latest [Node.js](https://nodejs.org/) LTS version (or latest current release). See [official installation instructions](https://nodejs.org/en/download/package-manager/).
+- [Yarn 1 (Classic)](https://legacy.yarnpkg.com/). See [official installation instructions](https://legacy.yarnpkg.com/docs/install).
 
 Then install The Lounge using:
 


### PR DESCRIPTION
This PR adjusts the wording on the [Install and upgrade](https://thelounge.chat/docs/install-and-upgrade) page to make it clearer that The Lounge specifically requires Yarn 1 (Classic), instead of a more modern version of Yarn.

Following a recent discussion in IRC:

```
15:48 <Maxpm> When installing The Lounge from an npm release,
              do you recommend using Yarn 1 instead of a modern Yarn?
15:50 <Maxpm> The instructions at https://thelounge.chat/docs/install-and-upgrade#from-npm-releases
              use `yarn global add`. That command doesn't exist in more modern versions because
              "managing system-wide packages is outside of the scope of yarn."
15:51 <Maxpm> There's `yarn dlx`, to download and run a command from a temporary environment,
              but I don't know if that's appropriate thing to put in a systemd service file or whatever.

15:58 <+bookworm> Maxpm: TL doesn't support yarn 2
15:58 <+bookworm> yarn 2 is a completely different approach and less of an upgrade

16:01 <Maxpm> Cool, thanks for clarifying. Would you accept a PR to note that in the install docs,
              for the benefit of those of us less versed in the JS ecosystem?
16:02 <Maxpm> The current docs do link to Yarn 1, but I guess I thought it was an accidentally outdated link.

16:03 <+bookworm> sure
```