### PR TITLE
Don't mention `npm` command for installation

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -103,9 +103,6 @@ Then install The Lounge using:
 yarn global add thelounge
 ```
 
-{: .alert.alert-info role="alert"}
-If you install The Lounge using the [npm](https://docs.npmjs.com/cli/npm) CLI instead, you will need the `--unsafe-perm` flag: `npm install --global --unsafe-perm thelounge`
-
 Start the server manually using:
 
 ```


### PR DESCRIPTION
[The v4.3.1 release notes say:](https://github.com/thelounge/thelounge/releases/tag/v4.3.1)

> Also note that the npm package manager is no longer officially supported by The Lounge and we now only support using [yarn](https://yarnpkg.com/).

I take this to mean that we should always install with `yarn global add`, and never with `npm install --global`. That would mean that this mention of `npm install --global` on the "Install and upgrade" page is obsolete. So, remove it.

I'm unfamiliar with Javascript package management, so forgive me if I've missed the point!