### PR TITLE
Update reverse-proxies.md

### DIFF
--- a/_guides/reverse-proxies.md
+++ b/_guides/reverse-proxies.md
@@ -103,8 +103,9 @@ ProxyAddHeaders On
 ProxyPass /irc/ http://127.0.0.1:9000/
 ProxyPassReverse /irc/ http://127.0.0.1:9000/
 
-# By default Apache times out connections after one minute
-ProxyTimeout 86400 # 1 day
+# By default Apache times out connections after one minute,
+# set to 86400 seconds (1 day) instead
+ProxyTimeout 86400
 ```
 
 ## [Caddy](https://caddyserver.com/)


### PR DESCRIPTION
The `# 1 day` after the `ProxyTimeout` setting makes Apache to crash on restart/reload.