### PR TITLE
Nodejs documentation link update

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -11,7 +11,7 @@ order: 2
 
 First, make sure latest [Node.js](https://nodejs.org/) <abbr title="Long Term Support">LTS</abbr> version or latest current release is installed
 with `dpkg -s nodejs | grep '^Version'` and `node --version`. If not, follow the instructions given on the
-[official documentation](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions).
+[official documentation](https://github.com/nodesource/distributions).
 
 Then download `thelounge.deb` located at the bottom of [the latest release](https://github.com/thelounge/thelounge-deb/releases/latest).
 

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -11,7 +11,7 @@ order: 2
 
 First, make sure latest [Node.js](https://nodejs.org/) <abbr title="Long Term Support">LTS</abbr> version or latest current release is installed
 with `dpkg -s nodejs | grep '^Version'` and `node --version`. If not, follow the instructions given on the
-[official documentation](https://github.com/nodesource/distributions).
+[official documentation](https://github.com/nodesource/distributions?tab=readme-ov-file#debian-and-ubuntu-based-distributions).
 
 Then download `thelounge.deb` located at the bottom of [the latest release](https://github.com/thelounge/thelounge-deb/releases/latest).
 


### PR DESCRIPTION
Currently pointing to https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions "nvm" is not a package manager.