### PR TITLE
master: Fix deprecated links to Yarn Classic in install-and-upgrade

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -98,7 +98,7 @@ packages.
 First, make sure you have these installed on your system:
 
 - The latest [Node.js](https://nodejs.org/) LTS version (or latest current release). See the [official installation instructions](https://nodejs.org/en/download/package-manager/).
-- [Yarn 1 (classic)](https://legacy.yarnpkg.com/). See [official installation instructions](https://legacy.yarnpkg.com/docs/install).
+- [Yarn 1 (classic)](https://classic.yarnpkg.com/lang/en/). See [official installation instructions](https://classic.yarnpkg.com/en/docs/install).
 
 Then install The Lounge using:
 


### PR DESCRIPTION
Replace old, deprecated links to Yarn Classic (version 1) in the docs, which led to a 404 page.
Fixes: https://github.com/thelounge/thelounge.github.io/issues/283

Old links were:
https://legacy.yarnpkg.com/ & https://legacy.yarnpkg.com/docs/install

Current working links are:
https://classic.yarnpkg.com/lang/en/ & https://classic.yarnpkg.com/en/docs/install

Files changed:
- _docs/install-and-upgrade.md

The only instance of these links seems to be this in this file, based on a `grep` search.